### PR TITLE
Only add to Timber context if a Product or Product Collection

### DIFF
--- a/app/timber-setup.php
+++ b/app/timber-setup.php
@@ -12,11 +12,15 @@ class TimberSetup {
   }
 
   public function add_to_context($context) {
+    global $post;
+    if ($post && $post->post_type !== 'product_collection' && $post->post_type !== 'product') {
+      return $context;
+    }
 
     $product_collection = new TimberPost(get_page_by_path('best-beauty', OBJECT, 'product_collection'));
     $product_collection_categories = get_field('categories', $product_collection->ID);
 
-    global $post;
+
     $context['post'] = new TimberPost($post);
     $context['product_plugin'] = new stdClass();
     $context['product_plugin']->js_file = $this->get_js_file();


### PR DESCRIPTION
## What you've done
The Twig context for this Product plugin should only run on Product/Product Collection pages

## Why have you done it
Massive performance hit. Retrieving the Product Collection contained all the Products as full objects. Ridiculously heavy.

## Screenshot (if visual)
...

## Testing carried out to prevent breaking changes
Best Beauty pages still work, so do normal Posts and Partnerships
